### PR TITLE
changed TARGET to send to EVERYONE

### DIFF
--- a/php/Push4Parse.php
+++ b/php/Push4Parse.php
@@ -11,8 +11,7 @@
 	
 	$data = json_encode(
 		array(
-			'channels' => $channels, 
-			'type' => 'ios',
+			'where' => '{}',
 			'data' => array(
 						'alert' => $alert,
 						'sound' => 'push.caf',


### PR DESCRIPTION
Noticed when sending from a device that the TARGET was set to CHANNELS and the notification was never received on the device. When sending from parse.com website the TARGET was set to EVERYONE. I edited this file based on this post I found on parse.com https://parse.com/questions/how-can-i-send-push-notifications-using-aspnet-or-php that corrects the issue and sets the TARGET to EVERYONE.
