### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@ Push4Parse
 ==========
 > Push4Parse is an elegant notification composer for http://parse.com, a service that allows you to send push notifications to your iOS apps easily.  Push4Parse makes it easy to send notifications to your app on the go with a fun, easy to use UI and simple application adding process.  The app is available on the [App Store](https://appsto.re/i6FG3gt).  
 
-##Screenshots
+## Screenshots
 <img src='http://i.imgur.com/OlbIqM5.png' />
 
-##Building & Configuration
+## Building & Configuration
 
-###The Backend
-####Hosted Domain
+### The Backend
+#### Hosted Domain
 
 To run on a domain, just upload the `Push4Parse.php` file found in the **php** folder.
 
-####Locally
+#### Locally
 
 Open up Terminal and run
 
@@ -25,12 +25,12 @@ Depending on the method you did above, you will now either be able to locate the
 
 ===
 
-###The App
-#####You've used CocoaPods before
+### The App
+##### You've used CocoaPods before
 Run `pod install` in the **ios** folder just to be safe.
 
 
-#####New to CocoaPods
+##### New to CocoaPods
 Oepn up Terminal and run 
 
 ```
@@ -42,7 +42,7 @@ See [CocoaPods](http://cocoapods.org) for more information on using CocoaPods in
 
 ===
 
-###Changes
+### Changes
 
 Having done all of the above, you now need to make a few changes in the actual code.  
 
@@ -50,7 +50,7 @@ Open up the .xcworkspace and in `SendNotificationViewController.m` on line **96*
 
 If you have any errors, or are having trouble with the above, [open an issue](https://github.com/trigon/Push4Parse/issues).
 
-##License
+## License
 
 The MIT License (MIT)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
